### PR TITLE
chore: decrease upgrade interval from 5m to 15m

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -48,7 +48,7 @@ sinker:
 
 periodics:
 - name: upgrade
-  interval: 5m
+  interval: 15m
   agent: knative-build
   build_spec:
     serviceAccountName: jenkins


### PR DESCRIPTION
attempting to reduce the number of build pods created