### PR TITLE
Remove policy-engine from jenkins-x prod cluster

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -35,9 +35,6 @@ branch-protection:
         haha:
           required_status_checks:
             contexts: ["serverless-jenkins"]
-        policy-engine:
-          required_status_checks:
-            contexts: ["serverless-jenkins"]
         cloudbees-apps:
           required_status_checks:
             contexts: ["serverless-jenkins"]
@@ -472,16 +469,6 @@ postsubmits:
       template:
         name: jenkins-go
     name: release
-  
-  cloudbees/policy-engine:
-  - agent: knative-build
-    branches:
-    - master
-    build_spec:
-      serviceAccountName: knative-build-bot
-      template:
-        name: jenkins-go
-    name: release  
 
   cloudbees/cloudbees-apps:
   - agent: knative-build
@@ -999,18 +986,6 @@ presubmits:
     rerun_command: /test this
     trigger: (?m)^/test( all| this),?(\s+|$)  
 
-  cloudbees/policy-engine:
-  - agent: knative-build
-    always_run: true
-    build_spec:
-      serviceAccountName: knative-build-bot
-      template:
-        name: jenkins-go
-    context: serverless-jenkins
-    name: serverless-jenkins
-    rerun_command: /test this
-    trigger: (?m)^/test( all| this),?(\s+|$)
-
   cloudbees/cloudbees-apps:
   - agent: knative-build
     always_run: true
@@ -1058,7 +1033,6 @@ tide:
     - cloudbees/core-backend
     - cloudbees/core-frontend
     - cloudbees/haha
-    - cloudbees/policy-engine
     - cloudbees/cloudbees-apps
   - labels:
     - approved
@@ -1108,7 +1082,6 @@ tide:
     - cloudbees/core-backend
     - cloudbees/core-frontend
     - cloudbees/haha
-    - cloudbees/policy-engine
     - cloudbees/cb-app-slack
     - cloudbees/cloudbees-apps
     - cloudbees/policy-tests

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -21,7 +21,6 @@ triggers:
   - core-frontend
   - core-backend
   - haha
-  - policy-engine
   - cloudbees-apps
   - cb-app-slack
   trusted_org: cloudbees
@@ -268,19 +267,6 @@ plugins:
   - wip
   - cat
   cloudbees/haha:
-  - approve
-  - heart
-  - assign
-  - blunderbuss
-  - help
-  - hold
-  - lgtm
-  - lifecycle
-  - size
-  - trigger
-  - wip
-  - cat
-  cloudbees/policy-engine:
   - approve
   - heart
   - assign


### PR DESCRIPTION
We use our own cluster now so we don't need to be built in the jx prod
cluster