### PR TITLE
Removing jenkins-x-serverless from pre-submits

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -702,18 +702,6 @@ presubmits:
     rerun_command: /test this
     trigger: (?m)^/test( all| this),?(\s+|$)
 
-  jenkins-x/jenkins-x-serverless:
-  - agent: knative-build
-    always_run: true
-    build_spec:
-      serviceAccountName: knative-build-bot
-      template:
-        name: jenkins-go
-    context: serverless-jenkins
-    name: serverless-jenkins
-    rerun_command: /test this
-    trigger: (?m)^/test( all| this),?(\s+|$)
-
   jenkins-x/jenkins-x-serverless-filerunner:
   - agent: knative-build
     always_run: true


### PR DESCRIPTION
Removing jenkins-x-serverless from pre-submits as it's moving over to the tekton enabled temporary cluster